### PR TITLE
changes to even-odd

### DIFF
--- a/R/evenodd.R
+++ b/R/evenodd.R
@@ -24,10 +24,13 @@ evenodd <- function(x, factors, diag = FALSE) {
 
   if(length(factors) == 1) {
     stop("You have called even-odd with only a single factor. \n The even-odd method requires multiple factors to work correctly.",
-            call. = TRUE) }
+            call. = FALSE) }
+  if(sum(factors) > ncol(x)) {
+    stop("The number of items specified by 'factors' exceeds the number of columns in 'x'.",
+            call. = FALSE) }
   if(sum(factors) != ncol(x)) {
     warning("The number of items specified by 'factors' does not match the number of columns in 'x'. \n Please check if this is what you want.",
-            call. = TRUE) }
+            call. = FALSE) }
 
   # initalize empty list for persons holding the persons even scores and odd scores
   eo_vals <- vector("list", nrow(x))

--- a/R/evenodd.R
+++ b/R/evenodd.R
@@ -21,8 +21,16 @@
 
 evenodd <- function(x, factors, diag = FALSE) {
   #initialize a result dataset
-  eo <- vector(length = nrow(x), mode = "numeric")
-  eo_missing <- vector(length = nrow(x), mode = "numeric")
+
+  if(length(factors) == 1) {
+    stop("You have called even-odd with only a single factor. \n The even-odd method requires multiple factors to work correctly.",
+            call. = TRUE) }
+  if(sum(factors) != ncol(x)) {
+    warning("The number of items specified by 'factors' does not match the number of columns in 'x'. \n Please check if this is what you want.",
+            call. = TRUE) }
+
+  # initalize empty list for persons holding the persons even scores and odd scores
+  eo_vals <- vector("list", nrow(x))
 
   # Loop through each Person
   for(i in 1:nrow(x)) {
@@ -43,20 +51,35 @@ evenodd <- function(x, factors, diag = FALSE) {
       f[j,1] <- mean(t(s[e_ind]), na.rm = TRUE)
       f[j,2] <- mean(t(s[o_ind]), na.rm = TRUE)
     }
-
-    # Calculate within-person correlation between even and odd sub-scales
-    # then apply the Spearman-Brown correction for split-half reliability
-    # and store the result in the output vector.
-    eo_missing[i] <- sum(!is.na(apply(f, 1, sum))) #number of even/odd pairs for which no comparison can be computed because of NAs
-    tmp <- stats::cor(f[,1], f[,2], use ="pairwise.complete.obs")
-    tmp <- (2*tmp)/(1+tmp)
-    if(!is.na(tmp) && tmp < -1) tmp <- -1
-    eo[i] <- tmp
-    rm(f)
+    # assign the even and odd values to eo_vals
+    eo_vals[[i]] <- f
   }
-  
-  eo = 0 - eo
-  
-  if(diag == FALSE) {return(eo)}
-  else {return(data.frame(eo, eo_missing))}
+
+
+  #calculate number of even/odd pairs for which no comparison can be computed because of NAs
+  eo_missing <- lapply(eo_vals, function(i) sum(!is.na(apply(i, 1, sum))))
+
+  # scan for persons for which no even-odd can be calculated when all values are same, leading to
+  # a correlation of NA because there is no variance/standard deviation.
+  eo_sdzero <-  lapply(eo_vals, function(i) apply(i, 2, sd))
+  eo_sdzero <- sapply(eo_sdzero, function(i) any(i == 0))
+  if(any(eo_sdzero)) warning("One or more observations have zero variance in even and/or odd values. \nThis results in NA values for these observations.\nIncluding more factors may alleviate this issue.",
+                             call. = FALSE)
+
+  # Calculate within-person correlation between even and odd sub-scales
+  # then apply the Spearman-Brown correction for split-half reliability
+  # and store the result in the output vector.
+  eo_cor <- sapply(eo_vals, function(f) {
+    # suppressWarnings for standard deviation 0 which happens when each value-pairs is same
+    val <- suppressWarnings(stats::cor(f[, 1], f[, 2], use = "pairwise.complete.obs"))
+    val <- (2 * val) / (1 + val) #split-half
+    if (!is.na(val) && val < -1) val <- -1
+    return(val)
+  })
+
+  # transform eo  such that higher scores are indicating carelessness
+  eo_cor = 0 - eo_cor
+
+  if(diag == FALSE) {return(eo_cor)}
+  else {return(data.frame(eo_cor, eo_missing))}
 }


### PR DESCRIPTION
Fixes #22

I made some changes to evenodd:
1. Introduced error when calling even odd with just one factor. (Had to be an error rather than a warning because some later functions need the data to have `length(factor) > 1`)
2. Introduced warning when variables indicated by factor argument do not match the input data (x).
3. Use own warning for cases when NA arises because of 0 variance in even or odd vectors.
4. refactored some of the code using apply.