### PR TITLE
Refactored psychsyn, psychsyn_critval, and mahad

### DIFF
--- a/R/mahad.R
+++ b/R/mahad.R
@@ -35,7 +35,7 @@ mahad <- function(x, plot = TRUE, flag = FALSE, confidence = 0.99, na.rm = TRUE)
   x_filtered <- x[!complete.na,]
   
   if(any(is.na(x_filtered))) {
-    maha_data <- as.numeric(psych::outlier(x_filtered, plot, bad = 0, na.rm = na.rm))
+    maha_data <- as.numeric(psych::outlier(x_filtered, plot = FALSE, bad = 0, na.rm = na.rm))
     d_sq      <- rep_len(NA, nrow(x_filtered))
     d_sq[!complete.na] <- maha_data
     
@@ -50,33 +50,33 @@ mahad <- function(x, plot = TRUE, flag = FALSE, confidence = 0.99, na.rm = TRUE)
     
     cut     <- stats::qchisq(confidence, ncol(x))
     flagged <- (d_sq > cut)
-    
-    if (plot) {
-      plot_data <- data.frame(row     = seq_len(length(d_sq)),
-                              d_sq    = d_sq,
-                              flagged = flagged)
+  }
   
-      plot_data <- plot_data[order(plot_data$d_sq, decreasing = TRUE),]
-  
-      qqplot(x     = qchisq(ppoints(nrow(x_filtered)), df = ncol(x_filtered)),
-             y     = plot_data$d_sq,
-             main  = paste("Q-Q plot of Mahalanobis Distance",
-                           "versus Quantiles of Chi-Square"),
-             xlab  = "Quantiles of Chi-Square",
-             ylab  = "Mahalanobis Distance",
-             pch   = 16,
-             col   = rgb(0, .4, .6, .5))
-      abline(0, 1, col = "black", lty = 2)
-      if (any(plot_data$flagged)) {
-        text(x      = sort(qchisq(ppoints(nrow(x_filtered)), df = ncol(x_filtered)),
-                           decreasing = TRUE)[which(plot_data$flagged == TRUE)],
-             y      = plot_data$d_sq[which(plot_data$flagged == TRUE)],
-             labels = plot_data$row[which(plot_data$flagged == TRUE)],
-             pos    = 3)
-      }
+  if (plot) {
+    plot_data <- data.frame(row     = seq_len(length(d_sq)),
+                            d_sq    = d_sq,
+                            flagged = flagged)
+                
+    plot_data <- plot_data[order(plot_data$d_sq, decreasing = TRUE),]
+              
+    qqplot(x     = qchisq(ppoints(nrow(x_filtered)), df = ncol(x_filtered)),
+           y     = plot_data$d_sq,
+           main  = paste("Q-Q plot of Mahalanobis Distance",
+                         "versus Quantiles of Chi-Square"),
+           xlab  = "Quantiles of Chi-Square",
+           ylab  = "Mahalanobis Distance",
+           pch   = 16,
+           col   = rgb(0, .4, .6, .5))
+    abline(0, 1, col = "black", lty = 2)
+    if (any(plot_data$flagged)) {
+      text(x      = sort(qchisq(ppoints(nrow(x_filtered)), df = ncol(x_filtered)),
+                         decreasing = TRUE)[which(plot_data$flagged == TRUE)],
+           y      = plot_data$d_sq[which(plot_data$flagged == TRUE)],
+           labels = plot_data$row[which(plot_data$flagged == TRUE)],
+           pos    = 3)
     }
   }
-    
+  
   if(flag == TRUE) {
     return(data.frame(d_sq = d_sq, flagged = flagged))
   }

--- a/R/mahad.R
+++ b/R/mahad.R
@@ -36,7 +36,7 @@ mahad <- function(x, plot = TRUE, flag = FALSE, confidence = 0.99, na.rm = TRUE)
   
   if(any(is.na(x_filtered))) {
     maha_data <- as.numeric(psych::outlier(x_filtered, plot = FALSE, bad = 0, na.rm = na.rm))
-    d_sq      <- rep_len(NA, nrow(x_filtered))
+    d_sq      <- rep_len(NA, nrow(x))
     d_sq[!complete.na] <- maha_data
     
     cut     <- stats::qchisq(confidence, ncol(x))
@@ -45,7 +45,7 @@ mahad <- function(x, plot = TRUE, flag = FALSE, confidence = 0.99, na.rm = TRUE)
   } else {
     maha_data <- mahalanobis(x_filtered, center = colMeans(x_filtered), cov = cov(x_filtered))
   
-    d_sq <- rep_len(NA, nrow(x_filtered))
+    d_sq <- rep_len(NA, nrow(x))
     d_sq[!complete.na] <- maha_data
     
     cut     <- stats::qchisq(confidence, ncol(x))

--- a/R/psychsyn.R
+++ b/R/psychsyn.R
@@ -49,7 +49,12 @@ psychsyn <- function(x, critval=.60, anto=FALSE, diag=FALSE, resample_na=TRUE) {
 get_item_pairs <- function(x, critval=.60, anto=FALSE) {
   critval <- abs(critval) #Dummy Proofing
   
-  correlations <- stats::cor(x, use = "pairwise.complete.obs")
+  if(any(is.na(x))) {
+    correlations <- stats::cor(x, use = "pairwise.complete.obs")
+  } else {
+    correlations <- stats::cor(x, use = "everything")
+  }
+  
   correlations[upper.tri(correlations, diag=TRUE)] <- NA
   correlations <- as.data.frame(as.table(correlations))
 
@@ -82,7 +87,11 @@ syn_for_one <- function(x, item_pairs, resample_na) {
 
     # helper that calculates within-person correlation
     psychsyn_cor <- function(x) {
-      suppressWarnings(stats::cor(x, use = "pairwise.complete.obs", method = "pearson")[1,2])
+      if(any(is.na(x))) {
+        suppressWarnings(stats::cor(x, use = "pairwise.complete.obs")[1,2])
+      } else {
+        suppressWarnings(stats::cor(x, use = "everything")[1,2])
+      }
     }
 
     # if resample_na == TRUE, re-calculate psychsyn should a result return NA

--- a/R/psychsyn_critval.R
+++ b/R/psychsyn_critval.R
@@ -13,7 +13,13 @@
 #' psychsyn_cor <- psychsyn_critval(careless_dataset, anto = TRUE)
 
 psychsyn_critval <- function(x, anto = FALSE) {
-  correlations <- stats::cor(x, use = "pairwise.complete.obs")
+  
+  if(any(is.na(x))) {
+    correlations <- stats::cor(x, use = "pairwise.complete.obs")
+  } else {
+    correlations <- stats::cor(x, use = "everything")
+  }
+  
   correlations[upper.tri(correlations, diag=TRUE)] <- NA
   correlations <- as.data.frame(as.table(correlations))
 


### PR DESCRIPTION
First off, I really appreciate your package. It has drastically improved my data screening workflow.

With respect to this pull request, I noticed that `psychsyn` could take a while to calculate the psychometric synonym scores, especially when there was a large number of items in the dataset. I identified `stats::cor(x, use = "pairwise.complete.obs")` (and specifically `use = "pairwise.complete.obs"`) as the culprit. As such, I updated the code to only use `"pairwise.complete.obs"` when the dataset is not complete. 

In terms of time savings, the screenshots included below show that, when there is missing data, the old and refactored versions of `psychsyn` perform comparably. However, when the data _is_ complete, the function provides the psychometric synonym scores in less than half the time.

**psychsyn old (complete data)**
![psychsyn_complete_old](https://user-images.githubusercontent.com/25355753/119381370-0ae6e900-bc76-11eb-9f7a-799151ff3a59.png)
**psychsyn old (incomplete data)**
![psychsyn_nas_old](https://user-images.githubusercontent.com/25355753/119381385-0b7f7f80-bc76-11eb-935e-42c9822b251d.png)
**psychsyn new (complete data)**
![psychsyn_complete_new](https://user-images.githubusercontent.com/25355753/119381391-0c181600-bc76-11eb-851d-a197f77866fc.png)
**psychsyn new (incomplete data)**
![psychsyn_nas_new](https://user-images.githubusercontent.com/25355753/119381397-0c181600-bc76-11eb-97d9-a4f431381867.png)

Best,
Cameron